### PR TITLE
Fix highlighting of comments with interpolations

### DIFF
--- a/hcl-mode.el
+++ b/hcl-mode.el
@@ -64,13 +64,18 @@
   `((,hcl--assignment-regexp 1 font-lock-variable-name-face)
     (,hcl--boolean-regexp . font-lock-constant-face)
     (,hcl--map-regexp 1 font-lock-type-face)
-    (,hcl--string-interpolation-regexp 0 font-lock-variable-name-face t)))
+    (hcl--string-interpolation-matcher 0 font-lock-variable-name-face t)))
 
 (defsubst hcl--paren-level ()
   (car (syntax-ppss)))
 
 (defsubst hcl--in-string-or-comment-p ()
   (nth 8 (syntax-ppss)))
+
+(cl-defun hcl--string-interpolation-matcher (lim)
+  (while (re-search-forward hcl--string-interpolation-regexp lim t)
+    (when (nth 3 (syntax-ppss))
+      (cl-return-from hcl--string-interpolation-matcher (point)))))
 
 (defun hcl--block-indentation ()
   (let ((curline (line-number-at-pos)))


### PR DESCRIPTION
Fix highlighting of interpolated strings within comments, where the face of interpolation variables would previously override the comment face.