### PR TITLE
Handle missing argument in `hcl-end-of-defun`

### DIFF
--- a/hcl-mode.el
+++ b/hcl-mode.el
@@ -129,6 +129,7 @@
 
 (defun hcl-end-of-defun (&optional count)
   (interactive "p")
+  (setq count (or count 1))
   (let ((paren-level (hcl--paren-level)))
     (when (or (and (looking-at-p "}") (= paren-level 1))
               (= paren-level 0))


### PR DESCRIPTION
Passing `count` to `hcl-end-of-defun` is optional, but not doing so would result in an error. For instance, calling `mark-defun` fails with the error "end-of-defun: Wrong type argument: number-or-marker-p, nil".

Setting the default value to 1 avoids this problem, similar to what is done in `hcl-beginning-of-defun`.