### PR TITLE
fix: handle infinite loop if paren level never increases

### DIFF
--- a/hcl-mode.el
+++ b/hcl-mode.el
@@ -146,7 +146,8 @@
     (skip-chars-forward "^{")
     (forward-char 1)
     (let ((orig-level (hcl--paren-level)))
-      (while (>= (hcl--paren-level) orig-level)
+      (while (and (>= (hcl--paren-level) orig-level)
+                  (< (point) (point-max)))
         (skip-chars-forward "^}")
         (forward-line +1)))))
 


### PR DESCRIPTION
If the point is inside an unterminated heredoc, the paren level as reported by `syntax-ppss` will never increase because all the closing brackets are parsed as part of the string.  In this case Emacs freezes as the while loop never terminates, eventually ending at the end of the file.