### PR TITLE
Do not change the buffer if indentation is correct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,4 +33,4 @@ test:
 clean-elc:
 	rm -f f.elc
 
-.PHONY:	all compile clean-elc package-lint
+.PHONY:	all compile clean-elc package-lint test

--- a/hcl-mode.el
+++ b/hcl-mode.el
@@ -104,7 +104,6 @@
 
 (defun hcl-calculate-indentation ()
   (let ((block-indentation (hcl--block-indentation)))
-    (delete-region (line-beginning-position) (point))
     (if block-indentation
         (if (looking-at "[]}]")
             block-indentation

--- a/hcl-mode.el
+++ b/hcl-mode.el
@@ -102,6 +102,15 @@
                    (forward-line -1))))))
       (current-indentation))))
 
+(defun hcl-calculate-indentation ()
+  (let ((block-indentation (hcl--block-indentation)))
+    (delete-region (line-beginning-position) (point))
+    (if block-indentation
+        (if (looking-at "[]}]")
+            block-indentation
+          (+ block-indentation hcl-indent-level))
+      (hcl--previous-indentation))))
+
 (defun hcl-indent-line ()
   "Indent current line as Hcl configuration."
   (interactive)
@@ -110,15 +119,9 @@
     (back-to-indentation)
     (if (hcl--in-string-or-comment-p)
         (goto-char curpoint)
-      (let ((block-indentation (hcl--block-indentation)))
-        (delete-region (line-beginning-position) (point))
-        (if block-indentation
-            (if (looking-at "[]}]")
-                (indent-to block-indentation)
-              (indent-to (+ block-indentation hcl-indent-level)))
-          (indent-to (hcl--previous-indentation)))
-        (when (> (- (point-max) pos) (point))
-          (goto-char (- (point-max) pos)))))))
+      (indent-line-to (hcl-calculate-indentation))
+      (when (> (- (point-max) pos) (point))
+        (goto-char (- (point-max) pos))))))
 
 (defun hcl-beginning-of-defun (&optional count)
   (interactive "p")


### PR DESCRIPTION
When indenting the buffer, the plugin currently always modifies it, even when there's nothing to modify. Fix that.