### PR TITLE
Fix warnings in tests and compile tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          - 24.3
           - 24.5
           - 25.3
           - 26.3

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 EMACS ?= emacs
 
 # A space-separated list of required package names
-NEEDED_PACKAGES = package-lint ert
+NEEDED_PACKAGES = package-lint
 
 INIT_PACKAGES="(progn \
   (require 'package) \

--- a/Makefile
+++ b/Makefile
@@ -14,23 +14,32 @@ INIT_PACKAGES="(progn \
       (package-install pkg))) \
   )"
 
-all: compile test package-lint clean-elc
+all: compile-tests test package-lint clean-elc
 
 package-lint:
 	${EMACS} --eval ${INIT_PACKAGES} -batch -f package-lint-batch-and-exit hcl-mode.el
 
-compile: clean-elc
-	${EMACS} -batch -f batch-byte-compile *.el
+hcl-mode.elc: hcl-mode.el Makefile
+	${EMACS} -batch -f batch-byte-compile $<
 
-test:
+test/test-helper.elc: test/test-helper.el hcl-mode.elc
+	${EMACS} -L . -batch -f batch-byte-compile $<
+
+TESTS-EL = test/test-command.el test/test-highlighting.el test/test-indentation.el
+TESTS-ELC = test/test-command.elc test/test-highlighting.elc test/test-indentation.elc
+$(TESTS-ELC): test/test-helper.elc hcl-mode.elc $(TESTS-EL)
+	${EMACS} -L . -l test/test-helper.elc -batch -f batch-byte-compile test/test-command.el test/test-highlighting.el test/test-indentation.el
+compile-tests: $(TESTS-ELC)
+
+test: $(TESTS-ELC)
 	$(EMACS) -L . -batch \
-		-l test/test-helper.el \
-		-l test/test-indentation.el \
-		-l test/test-command.el \
-		-l test/test-highlighting.el \
+		-l test/test-helper.elc \
+		-l test/test-indentation.elc \
+		-l test/test-command.elc \
+		-l test/test-highlighting.elc \
 		-f ert-run-tests-batch-and-exit
 
 clean-elc:
 	rm -f f.elc
 
-.PHONY:	all compile clean-elc package-lint test
+.PHONY:	all clean-elc package-lint test

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,13 @@ INIT_PACKAGES="(progn \
 all: compile test package-lint clean-elc
 
 package-lint:
-	${EMACS} -Q --eval ${INIT_PACKAGES} -batch -f package-lint-batch-and-exit hcl-mode.el
+	${EMACS} --eval ${INIT_PACKAGES} -batch -f package-lint-batch-and-exit hcl-mode.el
 
 compile: clean-elc
-	${EMACS} -Q --eval ${INIT_PACKAGES} -L . -batch -f batch-byte-compile *.el
+	${EMACS} --eval ${INIT_PACKAGES} -L . -batch -f batch-byte-compile *.el
 
 test:
-	$(EMACS) -Q --eval ${INIT_PACKAGES} -L . -batch \
+	$(EMACS) --eval ${INIT_PACKAGES} -L . -batch \
 		-l test/test-helper.el \
 		-l test/test-indentation.el \
 		-l test/test-command.el \

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ package-lint:
 	${EMACS} --eval ${INIT_PACKAGES} -batch -f package-lint-batch-and-exit hcl-mode.el
 
 compile: clean-elc
-	${EMACS} --eval ${INIT_PACKAGES} -L . -batch -f batch-byte-compile *.el
+	${EMACS} -batch -f batch-byte-compile *.el
 
 test:
-	$(EMACS) --eval ${INIT_PACKAGES} -L . -batch \
+	$(EMACS) -L . -batch \
 		-l test/test-helper.el \
 		-l test/test-indentation.el \
 		-l test/test-command.el \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 EMACS ?= emacs
+BATCH_W_ERROR = -batch --eval "(setq byte-compile-error-on-warn t)"
 
 # A space-separated list of required package names
 NEEDED_PACKAGES = package-lint
@@ -17,18 +18,18 @@ INIT_PACKAGES="(progn \
 all: compile-tests test package-lint clean-elc
 
 package-lint:
-	${EMACS} --eval ${INIT_PACKAGES} -batch -f package-lint-batch-and-exit hcl-mode.el
+	${EMACS} --eval ${INIT_PACKAGES} $(BATCH_W_ERROR) -f package-lint-batch-and-exit hcl-mode.el
 
 hcl-mode.elc: hcl-mode.el Makefile
-	${EMACS} -batch -f batch-byte-compile $<
+	${EMACS} $(BATCH_W_ERROR) -f batch-byte-compile $<
 
 test/test-helper.elc: test/test-helper.el hcl-mode.elc
-	${EMACS} -L . -batch -f batch-byte-compile $<
+	${EMACS} -L . $(BATCH_W_ERROR) -f batch-byte-compile $<
 
 TESTS-EL = test/test-command.el test/test-highlighting.el test/test-indentation.el
 TESTS-ELC = test/test-command.elc test/test-highlighting.elc test/test-indentation.elc
 $(TESTS-ELC): test/test-helper.elc hcl-mode.elc $(TESTS-EL)
-	${EMACS} -L . -l test/test-helper.elc -batch -f batch-byte-compile test/test-command.el test/test-highlighting.el test/test-indentation.el
+	${EMACS} -L . -l test/test-helper.elc $(BATCH_W_ERROR) -f batch-byte-compile test/test-command.el test/test-highlighting.el test/test-indentation.el
 compile-tests: $(TESTS-ELC)
 
 test: $(TESTS-ELC)

--- a/test/test-command.el
+++ b/test/test-command.el
@@ -1,4 +1,4 @@
-;;; test-command.el --- test commands of hcl-mode
+;;; test-command.el --- test commands of hcl-mode  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2017 by Syohei YOSHIDA
 

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,4 +1,4 @@
-;;; test-helper.el --- helper for testing hcl-mode
+;;; test-helper.el --- helper for testing hcl-mode  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2017 by Syohei YOSHIDA
 

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -23,6 +23,12 @@
 
 (require 'hcl-mode)
 
+(if (fboundp 'font-lock-ensure)
+    (defalias 'hcl-mode--font-lock-ensure 'font-lock-ensure)
+  ;; `font-lock-ensure' didn't exist prior to Emacs 25
+  (defun hcl-mode--font-lock-ensure ()
+    (with-no-warnings (font-lock-fontify-buffer))))
+
 (defmacro with-hcl-temp-buffer (code &rest body)
   "Insert `code' and enable `hcl-mode'. cursor is beginning of buffer"
   (declare (indent 0) (debug t))
@@ -30,7 +36,7 @@
      (insert ,code)
      (goto-char (point-min))
      (hcl-mode)
-     (font-lock-fontify-buffer)
+     (hcl-mode--font-lock-ensure)
      ,@body))
 
 (defun forward-cursor-on (pattern)

--- a/test/test-highlighting.el
+++ b/test/test-highlighting.el
@@ -1,4 +1,4 @@
-;;; test-highlighting.el --- test for highlighting of hcl-mode
+;;; test-highlighting.el --- test for highlighting of hcl-mode  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2017 by Syohei YOSHIDA
 

--- a/test/test-indentation.el
+++ b/test/test-indentation.el
@@ -1,4 +1,4 @@
-;;; test-indentation.el --- test for indentation
+;;; test-indentation.el --- test for indentation  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2014 by Syohei YOSHIDA
 


### PR DESCRIPTION
This PR implements 3 things:

1. Fixes all compilation warnings in tests
2. Makes any byte-compilation warning an error
3. Makes tests rely on byte-compiled `.elc` files