### PR TITLE
keywords: allow labels in block definitions

### DIFF
--- a/hcl-mode.el
+++ b/hcl-mode.el
@@ -53,7 +53,7 @@
   (concat hcl--identifier-regexp "\\s-*=\\(?:[^>=]\\)"))
 
 (defconst hcl--map-regexp
-  (concat hcl--identifier-regexp "\\s-*{"))
+  (format "%1$s\\(?:\\s-*\"%1$s\"\\)*\\s-*{" hcl--identifier-regexp))
 
 (defconst hcl--boolean-regexp
   (concat "\\(?:^\\|[^.]\\)"

--- a/test/test-highlighting.el
+++ b/test/test-highlighting.el
@@ -75,6 +75,8 @@ output \"name\" {
    }
 }
 "
+    (forward-cursor-on "output")
+    (should (face-at-cursor-p 'font-lock-type-face))
 
     (forward-cursor-on "bar")
     (should (face-at-cursor-p 'font-lock-variable-name-face))


### PR DESCRIPTION
According to the spec, after a type labels are allowed:

https://developer.hashicorp.com/terraform/language/syntax/configuration#blocks

This allows labels to be in the block definition after the type so that the type is still properly highlighted.